### PR TITLE
Drop python 3.7 support due to EOL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Install Dependences
         run: |
           python -m pip install --upgrade ${{ env.DEPENDENCES }}
@@ -49,7 +49,7 @@ jobs:
       matrix:
         # YAML parse `3.10` to `3.1`, so we have to add quotes for `'3.10'`, see also:
         # https://github.com/actions/setup-python/issues/160#issuecomment-724485470
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
@@ -83,10 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Install Dependences
         run: |
           python -m pip install --upgrade ${{ env.DEPENDENCES }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.10"
           architecture: "x64"
       - name: Install  Dependencies
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,7 +46,7 @@ git commit -am "Release v${VERSION}"
 
 # Tag & Auto Release in GitHub Actions
 git tag -a "${VERSION}" -m "Release stmdency v${VERSION}"
-git push --tags
+git push tags/"${VERSION}"
 ```
 
 ## Ref

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,10 +17,6 @@ classifiers =
     Development Status :: 3 - Alpha
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -36,7 +32,7 @@ project_urls =
     Changelog = https://github.com/zhongjiajie/stmdency/releases
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 zip_safe = true
 platforms = any

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # under the License.
 
 [tox]
-envlist = auto-lint, lint, code-test, local-ci, doc-build, py{37,38,39,310,311,312}
+envlist = auto-lint, lint, code-test, local-ci, doc-build, py{38,39,310,311,312}
 
 [testenv]
 allowlist_externals =


### PR DESCRIPTION
python 3.7 is EOL on 2023-06-27 according from
https://devguide.python.org/versions/ so we remove it and bump to minor semver